### PR TITLE
Fix --no-palette test

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,13 +132,13 @@ mod tests {
 
     #[test]
     fn it_omits_the_escape_codes_with_no_palette() {
-        let output = get_success(&["./src/tests/red.png", "--max-colours=1"]);
+        let output = get_success(&["./src/tests/red.png", "--max-colours=1", "--no-palette"]);
 
         assert_eq!(output.exit_code, 0);
 
         assert!(
-            output.stdout == "\u{1b}[38;2;255;0;0m▇ #ff0000\u{1b}[0m\n" ||
-            output.stdout == "\u{1b}[38;2;254;0;0m▇ #fe0000\u{1b}[0m\n",
+            output.stdout == "#ff0000\n" ||
+            output.stdout == "#fe0000\n",
             "stdout = {:?}", output.stdout
         );
 


### PR DESCRIPTION
👋🏾 hello Alex! I was working on adding tests for #5 (PR incoming) and I noticed that the test for --no-palette was the same as the test without it. Seems like a copy paste error. I think this test is correct now, it passes!

Also I really like how you structure and name your tests. Tests have been something I am not-so-good-at and I am definitely going to try and mimic the way you do them. I didn't know there was a way to call the binary cargo outputs either! That's very nice.