### PR TITLE
Allow selecting colour output format

### DIFF
--- a/src/colour_output.rs
+++ b/src/colour_output.rs
@@ -1,0 +1,37 @@
+use std::str::FromStr;
+
+use palette::Srgb;
+
+pub enum ColourOutput {
+    Hex,
+    Rgb255,
+    Rgb01,
+}
+
+impl ColourOutput {
+    pub fn format_colour(&self, colour: &Srgb<u8>) -> String {
+        match self {
+            Self::Hex => format!("#{:02x}{:02x}{:02x}", colour.red, colour.green, colour.blue),
+            Self::Rgb255 => format!("rgb({}, {}, {})", colour.red, colour.green, colour.blue),
+            Self::Rgb01 => format!(
+                "rgb({:.3}, {:.3}, {:.3})",
+                colour.red as f32 / 255.0,
+                colour.green as f32 / 255.0,
+                colour.blue as f32 / 255.0
+            ),
+        }
+    }
+}
+
+impl FromStr for ColourOutput {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hex" => Ok(Self::Hex),
+            "rgb255" => Ok(Self::Rgb255),
+            "rgb01" => Ok(Self::Rgb01),
+            _ => Err(format!("'{}' is not a recognized output format. Accepted values are hex, rgb255, and rgb01.", s))
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,48 @@ mod tests {
         assert_eq!(output.stdout.matches("\n").count(), 8, "stdout = {:?}", output.stdout);
     }
 
+    #[test]
+    fn it_defaults_to_hex_output() {
+        let output = get_success(&["./src/tests/red.png", "--max-colours=1", "--no-palette"]);
+
+        assert_eq!(output.exit_code, 0);
+
+        assert!(
+            output.stdout == "#ff0000\n" || output.stdout == "#fe0000\n",
+            "stdout = {:?}", output.stdout
+        );
+
+        assert_eq!(output.stderr, "");
+    }
+
+    #[test]
+    fn it_prints_correct_rgb255() {
+        let output = get_success(&["./src/tests/red.png", "--max-colours=1", "--no-palette", "--output=rgb255"]);
+
+        assert_eq!(output.exit_code, 0);
+
+        assert!(
+            output.stdout == "rgb(255, 0, 0)\n" || output.stdout == "rgb(254, 0, 0)\n",
+            "stdout = {:?}", output.stdout
+        );
+
+        assert_eq!(output.stderr, "");
+    }
+
+    #[test]
+    fn it_prints_correct_rgb01() {
+        let output = get_success(&["./src/tests/red.png", "--max-colours=1", "--no-palette", "--output=rgb01"]);
+
+        assert_eq!(output.exit_code, 0);
+
+        assert!(
+            output.stdout == "rgb(1.000, 0.000, 0.000)\n" || output.stdout == "rgb(0.996, 0.000, 0.000)\n",
+            "stdout = {:?}", output.stdout
+        );
+
+        assert_eq!(output.stderr, "");
+    }
+
     // The image created in the next two tests was created with the
     // following command:
     //
@@ -197,6 +239,15 @@ mod tests {
         assert_eq!(output.exit_code, 1);
         assert_eq!(output.stdout, "");
         assert_eq!(output.stderr, "error: Invalid value: The argument 'NaN' isn't a valid value\n");
+    }
+
+    #[test]
+    fn it_fails_if_you_pass_an_invalid_output() {
+        let output = get_failure(&["./src/tests/red.png", "--output=cheese"]);
+
+        assert_eq!(output.exit_code, 1);
+        assert_eq!(output.stdout, "");
+        assert_eq!(output.stderr, "error: Invalid value: The argument 'cheese' isn't a valid value\n");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,11 @@
 extern crate clap;
 
 use clap::{App, Arg};
+use colour_output::ColourOutput;
 use kmeans_colors::get_kmeans_hamerly;
 use palette::{Lab, Pixel, Srgb, Srgba};
 
+mod colour_output;
 mod get_bytes;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -36,6 +38,13 @@ fn main() {
                     .help("Just print the hex values, not colour previews")
                     .takes_value(false)
             )
+            .arg(
+                Arg::with_name("output")
+                    .long("output")
+                    .help("how to output the colors. hex, rgb255, or rgb01")
+                    .default_value("hex")
+                    .takes_value(true)
+            )
             .get_matches();
 
     // This .unwrap() is safe because "path" is a required param
@@ -44,6 +53,8 @@ fn main() {
     // Get the max colours as a number.
     // See https://github.com/clap-rs/clap/blob/v2.33.1/examples/12_typed_values.rs
     let max_colours = value_t!(matches, "MAX-COLOURS", usize).unwrap_or_else(|e| e.exit());
+
+    let colour_output = value_t!(matches, "output", ColourOutput).unwrap_or_else(|e| e.exit());
 
     // There's different code for fetching bytes from GIF images because
     // GIFs are often animated, and we want a selection of frames.
@@ -77,7 +88,7 @@ fn main() {
     // a palette of hex strings which are coloured to match.
     // See https://alexwlchan.net/2021/04/coloured-squares/
     for c in rgb {
-        let display_value = format!("#{:02x}{:02x}{:02x}", c.red, c.green, c.blue);
+        let display_value = colour_output.format_colour(c);
 
         if matches.is_present("no-palette") {
             println!("{}", display_value);


### PR DESCRIPTION
This PR attempts to close #5.

Here's some output using the three accepted arguments for `--output` with the lighthouse.

<details>
<summary><code>--output=hex</code> (default)</summary>
<pre><code>#e9e4d7
#858b88
#4576bb
#2c231b
#c53b4e
</code></pre>
</details>

<details>
<summary><code>--output=rgb255</code></summary>
<pre><code>rgb(233, 228, 215)
rgb(133, 139, 136)
rgb(69, 118, 187)
rgb(44, 35, 27)
rgb(197, 59, 78)
</code></pre>
</details>

<details>
<summary><code>--output=rgb01</code></summary>
<pre><code>rgb(0.914, 0.894, 0.843)
rgb(0.522, 0.545, 0.533)
rgb(0.271, 0.463, 0.733)
rgb(0.173, 0.137, 0.106)
rgb(0.773, 0.231, 0.306)
</code></pre>
</details>

`rgb01` formats the floats so that there is always 3 digits after the decimal. 3-digits after the decimal was chosen because 1 / 255 is roughly 0.004, so 2 digits would lose some precision. A side effect of this is that you *always* get 3-digits after the decimal, so a channel at its maximum will print "1.000" which I'm not sure is desirable behavior. It's quite verbose.