### PR TITLE
Add `--uppercase-hex`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,14 @@ struct Cli {
     /// Just print the hex values, not colour previews
     #[arg(long = "no-palette")]
     no_palette: bool,
+
+    /// Use uppercase hex (<span style="color: #7DC07B;">▇ #7DC07B</span>),
+    /// instead of lowercase (<span style="color: #7dc07b;">▇ #7dc07b</span>) when printing color codes.
+    #[arg(long = "uppercase-hex")]
+    #[arg(
+        help = "Use uppercase hex (#7DC07B), instead of lowercase (#7dc07b) when printing color codes."
+    )]
+    uppercase_hex: bool,
 }
 
 fn main() {
@@ -75,7 +83,7 @@ fn main() {
     };
 
     for c in rgb_colors {
-        printing::print_color(c, &cli.background, include_bg_color);
+        printing::print_color(c, &cli.background, include_bg_color, cli.uppercase_hex);
     }
 }
 

--- a/src/printing.rs
+++ b/src/printing.rs
@@ -5,10 +5,19 @@ use palette::Srgb;
 //
 // See https://alexwlchan.net/2021/04/coloured-squares/
 // See: https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797?permalink_comment_id=3857871
-pub fn print_color(c: Srgb<u8>, background: &Option<Srgb<u8>>, include_bg_colo: bool) {
-    let display_value = format!("#{:02x}{:02x}{:02x}", c.red, c.green, c.blue);
+pub fn print_color(
+    c: Srgb<u8>,
+    background: &Option<Srgb<u8>>,
+    include_bg_color: bool,
+    uppecase_hex: bool,
+) {
+    let display_value = if uppecase_hex {
+        format!("#{:02X}{:02X}{:02X}", c.red, c.green, c.blue)
+    } else {
+        format!("#{:02x}{:02x}{:02x}", c.red, c.green, c.blue)
+    };
 
-    if include_bg_colo {
+    if include_bg_color {
         // If a background colour is specified, print it behind the
         // hex strings.
         match background {


### PR DESCRIPTION
`--uppercase-hex` makes `dominant_colours` output uppercase hex (`#7DC07B`), instead of lowercase (`#7dc07b`) when printing color codes.

i have some ideas on minor improvements/cleanups to the code, but i'm unsure if you are interested in that. lmk if you do!